### PR TITLE
Fix a memory leak in CustomerLogger.Service()

### DIFF
--- a/customLogger.go
+++ b/customLogger.go
@@ -112,10 +112,12 @@ func (l *CustomLogger) Service() error {
 	}
 
 	var newFileName string
+	t := time.NewTicker(l.ConventionUpdate)
+	defer t.Stop()
 	for {
 		select {
 
-		case <-time.NewTicker(l.ConventionUpdate).C:
+		case <-t.C:
 
 			handle, newFileName, err = l.getFileHandle()
 			if err != nil {


### PR DESCRIPTION
The call to NewTicker() in the for loop causes a memory leak as each
Ticker that gets created never has its resources released by calling
Ticker.Stop().

This commit fixes the memory leak by creating only one Ticker before
entering the for loop.